### PR TITLE
docs: explain the internal of apisix-mesh-agent

### DIFF
--- a/docs/the-internal-of-apisix-mesh-agent.md
+++ b/docs/the-internal-of-apisix-mesh-agent.md
@@ -12,7 +12,7 @@ This article explains the internal design of apisix-mesh-agent.
 ## Overview
 
 The apisix-mesh-agent is modular, each modular exposes interfaces to let others invoke it.
-Now it has three modules: Provisioner, Adaptor, Cache. The dependency relationships between them are depicted by the following illustration.
+Now it has three modules: [Provisioner](#provisioner), [Adaptor](#adaptor), [Cache](#cache). The dependency relationships between them are depicted by the following illustration.
 
 ## Provisioner
 


### PR DESCRIPTION
* Written for the first time on 2021/02/23, add provisioner and adaptor explains.
* Revised on 2021/02/24, add cache explains.