### PR TITLE
feat: add connection_original_dst conneciton for routes

### DIFF
--- a/pkg/adaptor/xds/v3/route_test.go
+++ b/pkg/adaptor/xds/v3/route_test.go
@@ -300,7 +300,7 @@ func TestTranslateVirtualHost(t *testing.T) {
 			},
 		},
 	}
-	routes, err := a.translateVirtualHost("test", vhost)
+	routes, err := a.translateVirtualHost("test", vhost, nil)
 	assert.Nil(t, err)
 	assert.Len(t, routes, 1)
 	assert.Equal(t, routes[0].Name, "route1#test#test")
@@ -317,6 +317,25 @@ func TestTranslateVirtualHost(t *testing.T) {
 	assert.Equal(t, routes[0].Vars, []*apisix.Var{
 		{
 			Vars: []string{"request_method", "~~", "POST"},
+		},
+	})
+}
+
+func TestPatchRoutesWithOriginalDestination(t *testing.T) {
+	routes := []*apisix.Route{
+		{
+			Name: "1",
+			Id:   "1",
+		},
+	}
+	patchRoutesWithOriginalDestination(routes, "10.0.5.4:8080")
+	assert.Equal(t, routes[0].Vars, []*apisix.Var{
+		{
+			Vars: []string{
+				"connection_original_dst",
+				"==",
+				"10.0.5.4:8080",
+			},
 		},
 	})
 }

--- a/pkg/adaptor/xds/v3/types.go
+++ b/pkg/adaptor/xds/v3/types.go
@@ -31,7 +31,7 @@ var (
 type Adaptor interface {
 	// TranslateRouteConfiguration translates a RouteConfiguration to a series APISIX
 	// Routes.
-	TranslateRouteConfiguration(*routev3.RouteConfiguration) ([]*apisix.Route, error)
+	TranslateRouteConfiguration(*routev3.RouteConfiguration, *TranslateOptions) ([]*apisix.Route, error)
 	// TranslateCluster translates a Cluster to an APISIX Upstreams.
 	TranslateCluster(*clusterv3.Cluster) (*apisix.Upstream, error)
 	// TranslateClusterLoadAssignment translate the ClusterLoadAssignement resources to APISIX
@@ -40,6 +40,19 @@ type Adaptor interface {
 	// CollectRouteNamesAndConfigs collects Rds route names and static route configurations
 	// from listener.
 	CollectRouteNamesAndConfigs(*listenerv3.Listener) ([]string, []*routev3.RouteConfiguration, error)
+}
+
+// TranslateOptions contains some options to customize the translate process.
+type TranslateOptions struct {
+	// RouteOriginalDestination is a map which key is the name of RouteConfiguration
+	// and value is the original destination address that a connection should have
+	// to match this route. The original destination just happens to be the address
+	// of the listener.
+	// This is to obey the xDS specification as route configs are configured on listeners
+	// explicitly while there is no listener configuration on APISIX, so this is necessary
+	// to avoid the cross-listener-use of routes.
+	// An extra `vars` expression will be added only if the listener address can be found here.
+	RouteOriginalDestination map[string]string
 }
 
 type adaptor struct {

--- a/pkg/provisioner/xds/v3/file/delivery.go
+++ b/pkg/provisioner/xds/v3/file/delivery.go
@@ -26,7 +26,7 @@ func (p *xdsFileProvisioner) processRouteConfigurationV3(res *any.Any) []*apisix
 		return nil
 	}
 
-	routes, err := p.v3Adaptor.TranslateRouteConfiguration(&route)
+	routes, err := p.v3Adaptor.TranslateRouteConfiguration(&route, nil)
 	if err != nil {
 		p.logger.Errorw("failed to translate RouteConfiguration to APISIX routes",
 			zap.Error(err),

--- a/pkg/provisioner/xds/v3/grpc/delivery.go
+++ b/pkg/provisioner/xds/v3/grpc/delivery.go
@@ -26,7 +26,10 @@ func (p *grpcProvisioner) processRouteConfigurationV3(res *any.Any) ([]*apisix.R
 		return nil, err
 	}
 
-	routes, err := p.v3Adaptor.TranslateRouteConfiguration(&route)
+	opts := &xdsv3.TranslateOptions{
+		RouteOriginalDestination: p.routeOwnership,
+	}
+	routes, err := p.v3Adaptor.TranslateRouteConfiguration(&route, opts)
 	if err != nil {
 		p.logger.Errorw("failed to translate RouteConfiguration to APISIX routes",
 			zap.Error(err),
@@ -41,8 +44,11 @@ func (p *grpcProvisioner) processStaticRouteConfigurations(rcs []*routev3.RouteC
 	var (
 		routes []*apisix.Route
 	)
+	opts := &xdsv3.TranslateOptions{
+		RouteOriginalDestination: p.routeOwnership,
+	}
 	for _, rc := range rcs {
-		route, err := p.v3Adaptor.TranslateRouteConfiguration(rc)
+		route, err := p.v3Adaptor.TranslateRouteConfiguration(rc, opts)
 		if err != nil {
 			p.logger.Errorw("failed to translate RouteConfiguration to APISIX routes",
 				zap.Error(err),

--- a/pkg/provisioner/xds/v3/grpc/types_test.go
+++ b/pkg/provisioner/xds/v3/grpc/types_test.go
@@ -663,6 +663,16 @@ func TestTranslateListener(t *testing.T) {
 	assert.Nil(t, anypb.MarshalFrom(&any1, f1, proto.MarshalOptions{}))
 	li := &listenerv3.Listener{
 		Name: "listener1",
+		Address: &corev3.Address{
+			Address: &corev3.Address_SocketAddress{
+				SocketAddress: &corev3.SocketAddress{
+					Address: "10.0.5.3",
+					PortSpecifier: &corev3.SocketAddress_PortValue{
+						PortValue: 8080,
+					},
+				},
+			},
+		},
 		FilterChains: []*listenerv3.FilterChain{
 			{
 				Filters: []*listenerv3.Filter{


### PR DESCRIPTION
Routes in xDS are configured on Listeners explicitly, while APISIX doesn't have this mechanism so if we don't add extra limitations, the cross-listener-use of Routes might occur, therefor we added an extra condition in this PR to limit the use Route. Only if the `connection_original_dst` is matched, then the route can be used.

As APISIX doesn't have the dynamic listeners, this is a workaround way to support it.